### PR TITLE
Refactor _loadStore to use instance fields

### DIFF
--- a/assets/components/modai/mgr/js/agent/advanced_config.grid.js
+++ b/assets/components/modai/mgr/js/agent/advanced_config.grid.js
@@ -121,11 +121,12 @@ modAIAdmin.grid.AdvancedConfig = function (config) {
   modAIAdmin.grid.AdvancedConfig.superclass.constructor.call(this, config);
 };
 Ext.extend(modAIAdmin.grid.AdvancedConfig, MODx.grid.LocalGrid, {
-  _loadStore: function (config) {
-    return new Ext.data.JsonStore({
-      fields: config.fields,
+  _loadStore: function () {
+    this.store = new Ext.data.JsonStore({
+      fields: this.config.fields,
       remoteSort: false,
     });
+    return this.store;
   },
 
   getMenu: function () {


### PR DESCRIPTION
Prevents ModAI advanced config from breaking in modx 3.2

