### PR TITLE
docs: reorganize sidebar into a task-based reading order

### DIFF
--- a/docs/API/History-Module.md
+++ b/docs/API/History-Module.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # History Module
 
 The history module provides a state management system for tracking and navigating through historical values, with support for UI synchronization and context preservation.

--- a/docs/API/Initialization.md
+++ b/docs/API/Initialization.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Initialization
 
 modAI is available globally in manager, if you need to init it elsewhere, you can follow the instructions below.

--- a/docs/API/Initialization.md
+++ b/docs/API/Initialization.md
@@ -8,7 +8,7 @@ modAI is available globally in manager, if you need to init it elsewhere, you ca
 
 ## Loading up pre-requisites
 
-The following script will get the `modai` service (which can be `null` if it doesn't exist or if user doesn't have appropriate permissions). Then it loads lexicons needed for the modAI's UI and load the main JS file.
+The following script will get the `modai` service (which can be `null` if it doesn't exist or if user doesn't have appropriate permissions). Then it loads the lexicons needed for modAI's UI and loads the main JS file.
 
 ```php
 if (!$modx->services->has('modai')) {
@@ -31,7 +31,7 @@ $this->modx->regClientStartupScript($this->modAI->getJSFile());
 
 ## Initializing modAI
 
-When the main JS file is loaded, `ModAI.init` function will be available. It takes single `config` argument, with following parameters. We recommend using helper function to supply all necessary properties to the config `$modAI->getBaseConfig()`, you can check the usage in the example at the end of this page.
+When the main JS file is loaded, `ModAI.init` function will be available. It takes a single `config` argument, with the following parameters. We recommend using a helper function to supply all necessary properties to the config, `$modAI->getBaseConfig()`; you can check the usage in the example at the end of this page.
 
 ### Properties
 

--- a/docs/API/_category_.json
+++ b/docs/API/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Developer API",
+  "position": 6,
+  "link": {
+    "type": "generated-index",
+    "description": "Initialize modAI outside the manager and work with its internal modules."
+  }
+}

--- a/docs/Admin/Context-Providers.md
+++ b/docs/Admin/Context-Providers.md
@@ -31,6 +31,79 @@ To add a new provider:
 
 Once registered, the context provider appears in the **Context Provider** tab and you’ll be able to attach it to agents.
 
+### The `ContextProviderInterface`
+
+A custom provider implements `\modAI\ContextProviders\ContextProviderInterface`:
+
+```php
+public function __construct(modX $modx, array $config = []);
+
+// Return relevant context strings for a given prompt (this is the retrieval step).
+public function provideContext(string $prompt): array;
+
+// Admin-configurable options (rendered as a config form via ConfigBuilder).
+public static function getConfig(modX $modx): array;
+
+// Internal description shown to admins.
+public static function getDescription(): string;
+
+// The default provider name, pre-filled when configuring.
+public static function getSuggestedName(): string;
+```
+
+Throw `\modAI\Exceptions\InvalidContextProviderConfig` from the constructor when required config is missing — modAI catches it and shows a friendly error.
+
+:::note
+`provideContext()` is the only method the interface requires for retrieval. Indexing methods (`index()` / `delete()`) are **not** part of the interface — the built-in Pinecone provider adds them so it can sync MODX content into the vector database (see below).
+:::
+
+## Built-in Provider: Pinecone
+
+modAI ships a built-in **Pinecone** provider (`\modAI\ContextProviders\Pinecone`) for retrieval-augmented generation against a [Pinecone](https://www.pinecone.io/) vector index. The class is registered for selection out of the box, but **no provider instance is created automatically** — you configure one yourself.
+
+### Setup
+
+1. From the **Context Providers** tab, create a provider and choose the **Pinecone** class (the name pre-fills as `pinecone`).
+2. Fill in the configuration (at minimum `api_key`, `endpoint`, and `namespace`).
+3. **Enable** the provider and **attach it to an Agent**. A provider is only queried when it is enabled *and* linked to the agent in use.
+
+:::tip
+Any config value can be stored in a MODX system setting instead of inline by prefixing it with `ss:` — for example, set `api_key` to `ss:modai.pinecone_key` to read the secret from the `modai.pinecone_key` system setting.
+:::
+
+### Configuration
+
+| Key | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `api_key` | ✅ | – | Pinecone API key (sent as the `Api-Key` header). |
+| `endpoint` | ✅ | – | Your Pinecone index host URL (used as the API base URL). |
+| `namespace` | ✅ | – | Pinecone namespace to read from and write to. |
+| `api_version` | | `2025-04` | Pinecone API version (`X-Pinecone-API-Version` header). |
+| `fields` | | – | Comma-separated list of fields to index (which data gets stored and embedded). |
+| `fields_map` | | – | Comma-separated `original:new` pairs to rename fields on upsert. |
+| `id_field` | | – | Field used to format the record ID in output (supports `{field}` and `{++system_setting}` placeholders). |
+| `output_fields` | | – | Comma-separated list of result fields to include in the returned context. |
+| `context_messages` | | – | Templated lines prepended to each result. One per line; supports `{id}`, `{field}`, and `{++system_setting}` placeholders. |
+
+### How retrieval works
+
+When an agent runs, modAI sends the prompt to Pinecone using its **integrated embedding** (Pinecone embeds the query server-side — modAI does not compute vectors itself). It retrieves the top 5 candidates, then uses Pinecone's **integrated reranking** (`bge-reranker-v2-m3`) to narrow them to the top 3. Each result is formatted into a context string using your `context_messages` and `output_fields` settings and merged into the agent's context.
+
+### How indexing works
+
+The Pinecone provider can automatically **index your MODX content** as it changes — resources, chunks, snippets, and templates are upserted on save and removed on delete (via the core `OnDocFormSave`, `OnChunkSave`, `OnSnippetSave`, `OnTemplateSave` events and their delete counterparts). Each record is stored under an ID like `resource_42`, with a `text` field that Pinecone embeds.
+
+To enable auto-indexing, point each entity type at your provider using the `contexts` system settings — set them to the **name** of your Pinecone provider:
+
+| Setting | Indexes |
+| --- | --- |
+| `modai.contexts.resources.name` | Resources |
+| `modai.contexts.chunks.name` | Chunks |
+| `modai.contexts.snippets.name` | Snippets |
+| `modai.contexts.templates.name` | Templates |
+
+Leave a setting empty to skip auto-indexing for that type. The provider's `fields` option controls which data is actually stored and embedded.
+
 ## Configuring Context Providers in the Manager
 From the **Context Providers** tab you can:
 - Enable or disable providers.

--- a/docs/Admin/Context-Providers.md
+++ b/docs/Admin/Context-Providers.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Context Providers
 
 ## What a Context Provider Is

--- a/docs/Admin/Context-Providers.md
+++ b/docs/Admin/Context-Providers.md
@@ -21,8 +21,8 @@ Examples of what a Context Provider might expose:
 
 ## Registering Context Providers
 To add a new provider:
-- Implement a PHP class that follows the `\modAI\Tools\ToolInterface` interface.
-- Register the tool with modAI:
+- Implement a PHP class that follows the `\modAI\ContextProviders\ContextProviderInterface` interface.
+- Register the context provider with modAI:
     - Create a plugin that will run on `modAIOnContextProviderRegister` event and will return the class name of the Context Provider or an array of multiple context providers you wish to register.
 - Create the context provider from Context Providers tab:
     - Select the Context Provider class

--- a/docs/Admin/Prompt-Library.md
+++ b/docs/Admin/Prompt-Library.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Prompt Library
 
 ## Purpose

--- a/docs/Admin/Prompt-Library.md
+++ b/docs/Admin/Prompt-Library.md
@@ -18,4 +18,19 @@ In the library you can typically designate prompts as:
 
 This is useful for:
 - Team‑wide standard prompts (public).
-- Personal workflows
+- Personal workflows.
+
+Categories can also be marked public or private, governed by their own permissions (`modai_admin_prompt_library_prompt_save_public`, `modai_admin_prompt_library_category_save_public`). See [Permissions](../Configuration/Permissions.md).
+
+## Categories
+
+Prompts are organized into categories, which can be nested. modAI seeds two top-level categories on install:
+
+- **Text** – for text/textarea prompts.
+- **Image** – for image-generation prompts.
+
+Add your own categories and subcategories beneath these to keep reusable prompts organized by team, channel, or task.
+
+## Managing the Library
+
+The Prompt Library has its own Manager component (tab) where you can create, edit, categorize, and delete prompts and categories. Access is controlled by the `modai_admin_prompt_library*` permissions — for example, `modai_admin_prompt_library` to open the tab, `modai_admin_prompt_library_prompt_save` to create or update prompts, and `modai_admin_prompt_library_prompt_delete` to remove them.

--- a/docs/Admin/Tools.md
+++ b/docs/Admin/Tools.md
@@ -38,7 +38,7 @@ Once registered, the tool appears in the **Tools** tab and you’ll be able to a
 From the **Tools** tab you can:
 - Enable or disable individual Tools.
 - Edit the **user‑facing name** and **prompt/description**.
-- Whether a Tool is available in every prompt even without an agent
+- Set whether a Tool is available in every prompt, even without an agent.
 
 Changes here do not require you to redeploy code, which makes it a safe place to iterate on prompts and defaults.
 

--- a/docs/Admin/Tools.md
+++ b/docs/Admin/Tools.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Tools
 
 ## What a Tool Is

--- a/docs/Admin/Tools.md
+++ b/docs/Admin/Tools.md
@@ -15,11 +15,33 @@ In modAI, Tools are generally implemented as PHP classes that:
  
 Think of Tools as “functions” an agent can call to go beyond plain text generation.
 
-## Common Tool Examples
-- Edit or create MODX **Templates**, **Chunks**, or **Snippets**
-- Fetch and return content from specific Resources
-- Trigger indexing jobs for a Context Provider
-- Call a third‑party API (e.g., analytics, search, CRM) and return summarized data
+## Built-in Tools
+
+modAI ships with a set of tools that are **seeded and enabled on install**. They are *not* marked as "default", which means they only run when [attached to an Agent](Agents.md) (see [Availability](#availability) below).
+
+| Tool | What it does |
+| --- | --- |
+| `get_resources` | Find existing resources (matches pagetitle/longtitle/introtext; excludes deleted and non-searchable). |
+| `get_resource_detail` | Get full details for one or more resources by ID. |
+| `create_resource` | Create one or more resources (created unpublished). |
+| `edit_resource` | Edit an existing resource's content by ID (preserves MODX `[[ ]]` tags). |
+| `get_templates` | Find existing templates. |
+| `create_template` | Create one or more templates. |
+| `edit_template` | Edit an existing template by name. |
+| `get_chunks` | Find existing chunks. |
+| `create_chunk` | Create one or more chunks. |
+| `edit_chunk` | Edit an existing chunk by name. |
+| `get_categories` | List all element categories. |
+| `create_category` | Create one or more categories (with optional children). |
+| `get_weather` | Get current weather for a location (a simple demonstration tool). |
+
+The write tools (`create_*` / `edit_*`) enforce the matching MODX permission for the current user (e.g. `save_document`, `save_chunk`, `save_template`, `save_category`), so a tool can never let a user do something they couldn't do manually. The read/`get_*` tools and `get_weather` have no permission gate.
+
+Need something else — calling a third-party API, triggering indexing, summarizing external data? Build a [custom tool](#registering-tools).
+
+### The `clear_cache` config
+
+The six write tools (`create_resource`, `edit_resource`, `create_template`, `edit_template`, `create_chunk`, `edit_chunk`) expose a **`clear_cache`** config option (a yes/no field, enabled by default). When enabled, modAI refreshes the relevant MODX caches after the tool changes content.
 
 ## Registering Tools
 Tools are typically registered via configuration and/or service discovery. At a high level, you’ll:
@@ -34,13 +56,54 @@ Tools are typically registered via configuration and/or service discovery. At a 
 
 Once registered, the tool appears in the **Tools** tab and you’ll be able to attach it to agents.
 
+### The `ToolInterface`
+
+A custom tool implements `\modAI\Tools\ToolInterface`:
+
+```php
+public function __construct(modX $modx, array $config = []);
+
+// The default tool name, pre-filled when an admin configures it.
+public static function getSuggestedName(): string;
+
+// Internal description shown to admins.
+public static function getDescription(): string;
+
+// Natural-language instructions passed to the model explaining when/how to use the tool.
+public static function getPrompt(modX $modx): string;
+
+// Whether the current user is allowed to run the tool.
+public static function checkPermissions(modX $modx): bool;
+
+// The parameters the model must supply, as a JSON-Schema array.
+public static function getParameters(modX $modx): array;
+
+// Admin-configurable options for the tool (rendered as a config form). May be empty.
+public static function getConfig(modX $modx): array;
+
+// Execute the tool; returns a string (typically JSON-encoded).
+public function runTool(array $arguments): string;
+```
+
+The `getConfig()` form is built with modAI's `ConfigBuilder` (the same helper used by Context Providers), so you can expose typed fields to admins without writing UI code.
+
 ## Configuring Tools in the Manager
 From the **Tools** tab you can:
 - Enable or disable individual Tools.
 - Edit the **user‑facing name** and **prompt/description**.
-- Set whether a Tool is available in every prompt, even without an agent.
+- Set whether a Tool is **default** (available in every prompt, even without an agent).
+- Edit any tool-specific config (such as `clear_cache`).
 
 Changes here do not require you to redeploy code, which makes it a safe place to iterate on prompts and defaults.
+
+### Availability
+
+A tool runs in a conversation when **either**:
+
+- it is marked **default** (so it is offered in every prompt), **or**
+- it is **attached to the Agent** the user has selected.
+
+A tool must also be **enabled**, and the user must pass the tool's own `checkPermissions()`. The built-in tools are enabled but *not* default, so attach them to an Agent (or mark them default) to make them callable.
 
 ## Security Considerations
 Because tools can read or modify data:

--- a/docs/Admin/_category_.json
+++ b/docs/Admin/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Agents, Tools & Prompts",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Extend modAI with Tools, Context Providers, Agents, and a shared Prompt Library."
+  }
+}

--- a/docs/Configuration/Chat.md
+++ b/docs/Configuration/Chat.md
@@ -6,7 +6,7 @@ sidebar_position: 5
 
 ## Additional controls
 
-You can expose additional controls (select boxes) to the chat, both text and image mode. This allows you to present user with additional options, like selecting specific model or image quality.
+You can expose additional controls (select boxes) to the chat, both text and image mode. This allows you to present the user with additional options, like selecting a specific model or image quality.
 
 ### Format
 
@@ -17,7 +17,7 @@ To expose additional controls, update system setting `modai.chat.additional_cont
   "type": "object",
   "properties": {
     "image": {
-      "description": "Additional controles for the image mode",
+      "description": "Additional controls for the image mode",
       "type": "array",
       "items": [
         {
@@ -49,7 +49,7 @@ To expose additional controls, update system setting `modai.chat.additional_cont
       ]
     },
     "text": {
-      "description": "Additional controles for the text mode",
+      "description": "Additional controls for the text mode",
       "type": "array",
       "items": [
         {
@@ -86,7 +86,7 @@ To expose additional controls, update system setting `modai.chat.additional_cont
 
 ### Example
 
-Here's an example that will let user in text mode to select `Defaul`, `4o mini` or `4o` model and in the image mode `Default`, `Low` or `High` quality.
+Here's an example that lets the user select `Default`, `4o mini`, or `4o` as the model in text mode, and `Default`, `Low`, or `High` quality in image mode.
 
 ```JSON
 {

--- a/docs/Configuration/Chat.md
+++ b/docs/Configuration/Chat.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Chat
 
 ## Additional controls

--- a/docs/Configuration/Chat.md
+++ b/docs/Configuration/Chat.md
@@ -4,13 +4,90 @@ sidebar_position: 5
 
 # Chat
 
+Beyond the inline "sparkle button" fields, modAI ships a full **chat assistant** — a conversational UI built into the MODX Manager. The chat can generate text or images, remembers your conversations, and (when paired with [Agents](../Admin/Agents.md)) can call [Tools](../Admin/Tools.md) and pull from [Context Providers](../Admin/Context-Providers.md).
+
+## Opening the chat
+
+When `modai.init.global_chat` is enabled (it is by default), modAI adds an **AI assistant button** (a bot icon) to the main Manager left-hand menu. Click it to open the chat modal.
+
+The button only appears for users who have the `modai_client` permission **plus** at least one of `modai_client_chat_text` or `modai_client_chat_image` (see [Permissions](Permissions.md)).
+
+To hide the global button, set `modai.init.global_chat` to `No`.
+
+## Text and image chats
+
+The chat has two modes:
+
+- **Text** – conversational text generation. Requires `modai_client_chat_text`.
+- **Image** – image generation. Requires `modai_client_chat_image`.
+
+You can switch modes within the modal (subject to your permissions). Each mode keeps its own agents and history.
+
+## Chat history
+
+Chats are **persisted in the database**, so your conversations are saved between sessions and listed in the sidebar. The sidebar shows your own chats plus any [public chats](#public-chats), sorted **pinned first**, then by most recent activity.
+
+From the sidebar you can:
+
+- **Pin / unpin** a chat to keep it at the top of the list.
+- **Rename** a chat (titles can also be [generated automatically](#automatic-chat-titles)).
+- **Search** your chats — matches on both the chat title and the message content.
+- **Clone** a chat, duplicating it (and all its messages) into a new conversation.
+- **Delete** a chat, or delete a message and everything after it.
+
+:::note
+All history features (the sidebar, search, pin, clone, rename, delete) require the **`modai_client_chat_text`** permission specifically. A user with only `modai_client_chat_image` can generate images in the modal but won't have the persistent chat history features.
+:::
+
+## Public chats
+
+New chats default to **public**. In modAI, "public" means the chat is visible to **other Manager users** who have access to modAI — it is *not* an anonymous, externally shareable link, and there is no front-end route that exposes chats outside the Manager.
+
+- Other users see a public chat as **view-only**: they can read it and **clone** it, but cannot rename, pin, delete, or change its visibility.
+- Only the **owner** can toggle a chat between **Make Public** and **Make Private**.
+
+Use the sidebar's "show public chats" toggle to include or hide other people's public chats in your list.
+
+## Automatic chat titles
+
+When `modai.chat.title.generate` is enabled (default), modAI generates a short title from your **first message** in a conversation. This is a separate, lightweight AI call controlled by its own settings:
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `modai.chat.title.generate` | `Yes` | Whether to auto-generate titles. |
+| `modai.chat.title.model` | `openai/gpt-5-nano` | Model used to generate the title. |
+| `modai.chat.title.prompt` | *(see below)* | System instruction for the title model. |
+| `modai.chat.title.model_options` | `{"max_tokens": 16, "temperature": 0.7}` | JSON options for the title call. |
+
+The default prompt asks for a title of 32 characters or fewer with minimal punctuation. Title generation additionally requires the **`modai_client_text`** permission.
+
+## Using agents in chat
+
+If one or more [Agents](../Admin/Agents.md) are available for the current mode, an **agent dropdown** appears in the chat input. Selecting an agent changes the conversation in several ways:
+
+- The agent's **model** and advanced configuration (model, streaming, base prompt/output, custom options) are applied.
+- The agent's **system prompt** is injected into the conversation.
+- The agent's attached **Tools** become callable, and its attached **Context Providers** are queried to ground responses.
+
+Agents are filtered by type, so text agents appear in text chats and image agents in image chats. Access to each agent can be restricted by user group — see [Agents → Controlling Access](../Admin/Agents.md#controlling-access).
+
+:::info
+Tools are available in a chat when they are either marked as **default** (available in every prompt) **or** explicitly attached to the selected agent. See [Tools](../Admin/Tools.md).
+:::
+
+## Media browser integration
+
+When `modai.init.media_browser` is enabled (default), modAI adds an AI **generate** button to the MODX Media browser toolbar. It opens an **image** chat scoped to the active media source and path, and wires the generated image's download back into the browser — handy for creating hero or Open Graph images right where you manage files.
+
+Set `modai.init.media_browser` to `No` to remove it.
+
 ## Additional controls
 
-You can expose additional controls (select boxes) to the chat, both text and image mode. This allows you to present the user with additional options, like selecting a specific model or image quality.
+You can expose additional controls (select boxes) in the chat, for both text and image mode. This lets you present the user with extra options, like selecting a specific model or image quality.
 
 ### Format
 
-To expose additional controls, update system setting `modai.chat.additional_controls` with JSON that will follow this schema:
+To expose additional controls, update system setting `modai.chat.additional_controls` with JSON that follows this schema:
 
 ```JSON
 {
@@ -114,3 +191,14 @@ Here's an example that lets the user select `Default`, `4o mini`, or `4o` as the
 }
 
 ```
+
+## Permissions reference
+
+| Permission | Grants |
+| --- | --- |
+| `modai_client` | Base access to any modAI client feature. |
+| `modai_client_chat_text` | Text chat and all chat history features (sidebar, search, pin, public, clone, rename, delete). |
+| `modai_client_chat_image` | Image generation in the chat. |
+| `modai_client_text` | Required for automatic chat-title generation. |
+
+See [Permissions](Permissions.md) for the full list.

--- a/docs/Configuration/Cost.md
+++ b/docs/Configuration/Cost.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Cost
 
 OpenAI API credits must be purchased for this Extra to work with Image models. Find costs for the various models: [https://openai.com/api/pricing/](https://openai.com/api/pricing/)

--- a/docs/Configuration/Cost.md
+++ b/docs/Configuration/Cost.md
@@ -10,4 +10,4 @@ Google Gemini offers a variety of free options with limits. Image generation req
 
 Anthropic API pricing is here: [https://www.anthropic.com/pricing#anthropic-api](https://www.anthropic.com/pricing#anthropic-api)
 
-To learn more about managing cost, make sure to use the most optimal models for the type of content you expect your prompts to generate. For example, [1000 tokes is roughly equal to 750 words](https://platform.openai.com/docs/guides/production-best-practices#text-generation); make sure the [model you choose](https://platform.openai.com/docs/guides/model-selection) is the right one for the job at hand.
+To learn more about managing cost, make sure to use the most optimal models for the type of content you expect your prompts to generate. For example, [1000 tokens is roughly equal to 750 words](https://platform.openai.com/docs/guides/production-best-practices#text-generation); make sure the [model you choose](https://platform.openai.com/docs/guides/model-selection) is the right one for the job at hand.

--- a/docs/Configuration/Overview.md
+++ b/docs/Configuration/Overview.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Overview
 
 Use the [Supported Services](Supported-Services.md) section to set up your response AI service's credentials.

--- a/docs/Configuration/Overview.md
+++ b/docs/Configuration/Overview.md
@@ -23,6 +23,7 @@ If you have text, textarea, image or image+ Template Variables you wish to use w
 - **richtext inputs** – handled the same as a textarea input, but you must manually copy/paste the output into the textarea
 - **image inputs** – modAI uses the default image model and sizes and creates the images in the `assets/ai` directory
 - **image+ TVs** – handled the same as image inputs, with the addition of being able to use the Vision model for creating alt tag captions from generated images
+- **ImageCropper TVs** – supported the same way as image+ TVs
 
 ### Configuring Field Prompts
 
@@ -58,20 +59,30 @@ modai.global.text.model
 
 The `setting` for text or textarea inputs can contain several options below which will override the default settings from the `global` area:
 
-- **model** – for text or textarea, modAI defaults to use `openai/gpt-4o-mini`
+- **model** – for text or textarea, modAI defaults to `openai/gpt-5.5`
 - **temperature** – defaults to `0.7`, increase this to 1 for more “creative” results or 0 for highly predictable ones
 - **max_tokens** – defaults to `2048`
+- **base_output** – global output rules prepended to every text/textarea prompt; the defaults instruct the model to return clean, ready-to-use content with no explanation or surrounding quotes
+- **context_prompt** – template used to inject Context Provider results into the next message; defaults to `Here's context for next message, act only on this: {context}`
+
+:::note
+Default model names change between modAI releases as providers ship new models. The values below reflect the current defaults — always check your system settings for what's actually configured on your install.
+:::
 
 Image and Image+ fields do not prepend their prompts with the base prompt. Image/Image+ setting defaults in the `image` area include:
 
-- **model** – defaults to `openai/dall-e-3`
-- **quality** – defaults to `standard`
-- **size** – defaults to `1792x1024`
-- **style** – defaults to `vivid`
+- **model** – defaults to `openai/gpt-image-2`
+- **quality** – defaults to `auto`
+- **size** – defaults to `1024x1024`
+- **style** – no default (empty)
+- **path** – where generated images are saved; defaults to `assets/ai/{resourceId}/{hash}.png`
+- **media_source** – the MODX media source generated images are written to (defaults to the default source)
+- **download_domains** – optional allowlist of domains modAI may download generated images from
 
 Image+ fields can use Vision models to describe an image for the alt content found in the `vision` area:
 
-- **vision.model** – defaults to `openai/gpt-4o-mini`
+- **vision.model** – defaults to `openai/gpt-5-nano`
+- **vision.max_tokens** – defaults to `1024`
 
 ### Custom Options
 
@@ -92,3 +103,13 @@ If you'd like to stream the AI response into the UI (see the incrementally gener
 :::warning
 If you are executing requests on the server (`modai.api.execute_on_server` is set to `true`), make sure you configured your server to support streaming (disabled buffering etc.), you can make these changes only for the `/assets/components/modai/api.php` path.
 :::
+
+## Initialization & Integrations
+
+modAI loads itself into the Manager automatically. A few settings control where it appears and how its assets are cached:
+
+- **`modai.init.global_chat`** (default `Yes`) – shows the global AI [chat](Chat.md) button in the Manager menu.
+- **`modai.init.media_browser`** (default `Yes`) – adds an AI image-generation button to the Media browser. See [Chat → Media browser integration](Chat.md#media-browser-integration).
+- **`modai.cache.lit`** (default `0`) – a cache-busting version appended to modAI's JS/CSS URLs. Increment it to force browsers to reload modAI's assets after an update.
+
+To automatically index MODX content into a Pinecone vector database for retrieval, see the `modai.contexts.*` settings in [Context Providers → How indexing works](../Admin/Context-Providers.md#how-indexing-works).

--- a/docs/Configuration/Overview.md
+++ b/docs/Configuration/Overview.md
@@ -8,7 +8,7 @@ Use the [Supported Services](Supported-Services.md) section to set up your respo
 
 ## Models
 
-When defining model name you want to use, you have to enter it in following format: `service_name/model_name`, so for example `gpt-4o-mini` would become `openai/gpt-4o-mini`, `gemini-2.0-flash` would be `google/gemini-2.0-flash` etc.
+When defining the model name you want to use, you have to enter it in the following format: `service_name/model_name`, so for example `gpt-4o-mini` would become `openai/gpt-4o-mini`, `gemini-2.0-flash` would be `google/gemini-2.0-flash` etc.
 
 ## Generative Fields
 
@@ -26,14 +26,14 @@ If you have text, textarea, image or image+ Template Variables you wish to use w
 
 ### Configuring Field Prompts
 
-Customize the base prompts and configurations in the `global`, `image`, `resources` and `vision` areas in the system settings as needed. The `modai.global.text.base_prompt` prepends the base to ever other text or textarea prompt, but it does not for image or vision model prompts.
+Customize the base prompts and configurations in the `global`, `image`, `resources` and `vision` areas in the system settings as needed. The `modai.global.text.base_prompt` prepends the base to every other text or textarea prompt, but it does not for image or vision model prompts.
 
 ## Settings Format
 
 Settings use the following naming convention: `{namespace}.{field}.{type}.{setting}`.
 
 - Where `namespace` by default is `modai`, but other extras can pass their own to override default settings from their extra.
-- Field in the core modAI can be `res.pagetitle`, `res.longtitle`, `res.introtext`, `res.description`, `res.content` and `tv.tv_name` (for any text/image/image+ TV), but Extras can pass whatever make sense for them (for example TinyMCE RTE will pass `ta` for the content RTE instance). The field can also be `global` which is a fallback for any setting.
+- Field in the core modAI can be `res.pagetitle`, `res.longtitle`, `res.introtext`, `res.description`, `res.content` and `tv.tv_name` (for any text/image/image+ TV), but Extras can pass whatever makes sense for them (for example TinyMCE RTE will pass `ta` for the content RTE instance). The field can also be `global` which is a fallback for any setting.
 - Type can be one of `text`/`image`/`vision` to denote this setting will get only applied to AI interaction from the specific category
 - Setting is a target setting name like `model`, `temperature`, `quality`
 

--- a/docs/Configuration/Permissions.md
+++ b/docs/Configuration/Permissions.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Permissions
 
 modAI comes with `modAI Admin` access policy, `modAI` access policy template and following permissions:

--- a/docs/Configuration/Permissions.md
+++ b/docs/Configuration/Permissions.md
@@ -39,7 +39,7 @@ modAI comes with `modAI Admin` access policy, `modAI` access policy template and
 - modai_client_chat_image: Use modAI image generation
 
 ## Agents
-Access to specific agents can be controlled via assigning one or more user groups to the specific agent. If no user group is assigned, the agent is available for everyone. Sudo users have access to every agent, no matter what users groups are specified.
+Access to specific agents can be controlled via assigning one or more user groups to the specific agent. If no user group is assigned, the agent is available for everyone. Sudo users have access to every agent, no matter what user groups are specified.
 
 ## Image generation & Download
 To fully enable image generation & download for a user, user needs to have `modai_client_chat_image` permission, `file_create` permission and `create` policy on the specific media source that is configured as the target for download.

--- a/docs/Configuration/Supported-Services.md
+++ b/docs/Configuration/Supported-Services.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Supported AI Services
 
 ### Executing AI requests

--- a/docs/Configuration/Supported-Services.md
+++ b/docs/Configuration/Supported-Services.md
@@ -13,7 +13,7 @@ that can be easily revoked.
 
 Enabling system setting `modai.api.execute_on_server` will move the execution to the server side, hiding the network traffic.
 
-It can be enabled per service using `modai.api.{service}.execute_on_server}` format, for example, to enable this only for chatgpt, the setting would be: `modai.api.anthropic.execute_on_server`.
+It can be enabled per service using the `modai.api.{service}.execute_on_server` format. For example, to enable this only for ChatGPT, the setting would be: `modai.api.openai.execute_on_server`.
 
 ## OpenAI (ChatGPT)
 
@@ -33,7 +33,7 @@ ChatGPT is the default AI service assumed. Fill out the `modai.api.openai.key` a
   - **image to text** – [](https://ai.google.dev/gemini-api/docs/vision)
   - **image generation** – [](https://ai.google.dev/gemini-api/docs/imagen)
 
-Add a valide API key to the `modai.api.google.key` to use Google Gemini.
+Add a valid API key to the `modai.api.google.key` to use Google Gemini.
 
 To change a prompt to use Google Gemini, set its corresponding model setting, e.g:
 
@@ -42,7 +42,7 @@ To change a prompt to use Google Gemini, set its corresponding model setting, e.
 ## Anthropic (Claude)
 
 :::warning
-At this moment Claude can only work serverside. Setting either `modai.api.execute_on_server` or `modai.api.claude.execute_on_server` to `true`.
+At this moment Claude can only work server-side. Set either `modai.api.execute_on_server` or `modai.api.anthropic.execute_on_server` to `true`.
 :::
 
 - Service name: anthropic
@@ -73,13 +73,13 @@ To change a prompt to use OpenRouter, set its corresponding model setting, e.g:
 
 - Service name: custom
 
-Some services like [Open WebUI](https://docs.openwebui.com) provide a wrapper for multiple models. To use a custom model via these services you need to fill out the `modai.api.custom.url`, `modai.api.custom.key` and optionally the `modai.custom.compatibility`, which tells the model what API emulation to use (almost alway leave this as openai).
+Some services like [Open WebUI](https://docs.openwebui.com) provide a wrapper for multiple models. To use a custom model via these services you need to fill out the `modai.api.custom.url`, `modai.api.custom.key` and optionally the `modai.custom.compatibility`, which tells the model what API emulation to use (almost always leave this as openai).
 
 To use the custom service, set the following fields:
 
 - `modai.api.custom.url` → `{your custom URL}`
 - `modai.api.custom.key` → `{your API key}`
 
-Then, you for each model you want to use, set the corresponding "model" field with the prefix "custom/" followed by the model name, e.g:
+Then, for each model you want to use, set the corresponding "model" field with the prefix "custom/" followed by the model name, e.g:
 
 - `modai.global.model` → `custom/llama3.1:8b`

--- a/docs/Configuration/Supported-Services.md
+++ b/docs/Configuration/Supported-Services.md
@@ -73,7 +73,7 @@ To change a prompt to use OpenRouter, set its corresponding model setting, e.g:
 
 - Service name: custom
 
-Some services like [Open WebUI](https://docs.openwebui.com) provide a wrapper for multiple models. To use a custom model via these services you need to fill out the `modai.api.custom.url`, `modai.api.custom.key` and optionally the `modai.custom.compatibility`, which tells the model what API emulation to use (almost always leave this as openai).
+Some services like [Open WebUI](https://docs.openwebui.com) provide a wrapper for multiple models. To use a custom model via these services you need to fill out the `modai.api.custom.url`, `modai.api.custom.key` and optionally the `modai.api.custom.compatibility`, which tells modAI which API wire-format to use.
 
 To use the custom service, set the following fields:
 
@@ -83,3 +83,47 @@ To use the custom service, set the following fields:
 Then, for each model you want to use, set the corresponding "model" field with the prefix "custom/" followed by the model name, e.g:
 
 - `modai.global.model` → `custom/llama3.1:8b`
+
+The custom service speaks the OpenAI wire format and supports **text**, **vision**, **image generation**, and **image editing** (when image attachments are supplied). It calls `{url}/chat/completions`, `{url}/images/generations`, and `{url}/images/edits`.
+
+:::note
+`modai.api.custom.compatibility` defaults to `openai`, which is currently the only supported value — it's a forward-looking placeholder for future wire formats. Leave it as `openai`.
+:::
+
+## Registering Custom Services
+
+Beyond the OpenAI-compatible `custom` service above, developers can register an entirely new AI service in code by hooking the **`modAIOnServiceRegister`** event.
+
+A plugin on this event returns the fully-qualified class name(s) of your service classes (a JSON-encoded array matches the core convention):
+
+```php
+$modx->event->output(json_encode([
+    \MyExtra\Services\MyService::class,
+]));
+```
+
+Each class must implement `\modAI\Services\AIService`:
+
+```php
+public static function getServiceName(): string;          // e.g. "myservice" -> reads modai.api.myservice.key
+public static function isMyModel(string $model): bool;    // claim a model prefix, e.g. "myservice/"
+public function __construct(modX &$modx);
+public function getCompletions(array $data, CompletionsConfig $config): AIResponse;  // text / chat
+public function getVision(string $prompt, string $image, VisionConfig $config): AIResponse;
+public function generateImage(string $prompt, ImageConfig $config): AIResponse;
+```
+
+modAI resolves a `service/model` string by asking each registered service's `isMyModel()` whether it owns that **model prefix** — so pick a unique prefix that doesn't collide with the built-ins (`openai/`, `google/`, `anthropic/`, `openrouter/`, `custom/`). The part after the prefix is the real model id.
+
+Services don't make the HTTP call themselves. They build and return an `AIResponse` (`\modAI\Services\Response\AIResponse`) describing the request — URL, headers, body, parser, and streaming flag — and modAI executes it:
+
+```php
+return AIResponse::new(self::getServiceName(), $config->getRawModel())
+    ->withStream($config->isStream())
+    ->withParser('content')                 // 'content' for chat/vision, 'image' for image generation
+    ->withUrl(self::COMPLETIONS_API)
+    ->withHeaders(['Authorization' => 'Bearer ' . $apiKey])
+    ->withBody($input);
+```
+
+The `ApiKey` trait (`\modAI\Services\ApiKey`) provides a `getApiKey()` helper that reads `modai.api.{getServiceName()}.key`. Look at `\modAI\Services\OpenRouter` for a clean reference implementation. A service must implement all three modes, but unsupported ones can throw a `LexiconException`.

--- a/docs/Configuration/_category_.json
+++ b/docs/Configuration/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Configuration",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "description": "Set up modAI: connect AI services, control costs, manage permissions, and configure the chat."
+  }
+}

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Glossary
 
 ## Service

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Usage
 
-Wherever you see a field or a label with a “sparkle button” (✦) next to it, click it to use the chatGPT api to create content in those fields based on the system settings prompts/configurations. By default, it automatically creates sparkle buttons for several fields as outlined below. Delete the prompt settings to remove modAI’s sparkle buttons and the generative AI content creation for those fields:
+Wherever you see a field or a label with a “sparkle button” (✦) next to it, click it to use the configured AI service to create content in those fields based on the system settings prompts/configurations. By default, it automatically creates sparkle buttons for several fields as outlined below. Delete the prompt settings to remove modAI’s sparkle buttons and the generative AI content creation for those fields:
 
 - **longtitle** – often used for the SEO Meta Title manually or with SEO Suite (should be ~70 characters)
 - **description** – often used for the SEO Meta Description manually or with SEO Suite (should be ~155 characters)

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Usage
 
 Wherever you see a field or a label with a “sparkle button” (✦) next to it, click it to use the chatGPT api to create content in those fields based on the system settings prompts/configurations. By default, it automatically creates sparkle buttons for several fields as outlined below. Delete the prompt settings to remove modAI’s sparkle buttons and the generative AI content creation for those fields:


### PR DESCRIPTION
## Overview

A documentation overhaul for the `docs/` site (Docusaurus). Three focused commits: a structural reorganization, a grammar/correctness pass, and a large content expansion that closes gaps between the docs and the actual codebase. All new content was verified against `core/components/modai/` source.

## Commits

### 1. Reorganize the sidebar into a task-based reading order (`ecc8e3c`)
The sidebar was autogenerated with no explicit ordering, so pages sorted alphabetically — advanced admin internals showed up second and **Usage** landed at the bottom.

- Added `sidebar_position` frontmatter to every page and a `_category_.json` (label + position + landing page) to each folder.
- New order: About → **Usage** → **Configuration** → **Agents, Tools & Prompts** → **Glossary** → **Developer API**.
- Moved **Cost** into Configuration and the internal **History Module** reference into a new Developer API group.
- Added a new **Agents** page (Agents were referenced throughout but never documented).

### 2. Fix typos, grammar, and incorrect setting names (`29f0ae0`)
Copy-edit pass plus three correctness fixes verified against the PHP source:

- Context Providers implement `\modAI\ContextProviders\ContextProviderInterface`, not `\modAI\Tools\ToolInterface`.
- Anthropic's per-service server-execution setting is `modai.api.anthropic.execute_on_server` (`claude` is not a valid service token — `Anthropic::getServiceName()` returns `anthropic`).
- The "enable only for ChatGPT" example used the anthropic key; ChatGPT's service name is `openai`. Also removed a stray `}` from the setting format.
- Typo/grammar fixes across the docs (valide→valid, tokes→tokens, controles→controls, subject-verb agreement, etc.).

### 3. Document chat, built-in tools, Pinecone, custom services & more (`2e85527`)
Researched the implementation and wrote up the major undocumented surface area:

- **Chat** (rewritten): the global chat assistant — opening it, text/image modes, DB-persisted history, pinning, public chats (clarified: visible to other Manager users, not anonymous links), search, clone, auto-titles + settings, agents/tools/context-providers in chat, media-browser integration, and the permission model.
- **Tools**: a Built-in Tools reference (all 13 seeded tools), the `clear_cache` config, the `ToolInterface` signature, and an Availability note (enabled vs. default vs. agent-attached).
- **Context Providers**: the built-in **Pinecone** provider — config reference, setup, integrated embedding + reranking retrieval, and auto-indexing via the `modai.contexts.*` settings; plus the correct `ContextProviderInterface`.
- **Supported Services**: a "Registering Custom Services" section (`modAIOnServiceRegister`, the `AIService` interface, model-prefix resolution, the `AIResponse` builder); fixed the custom-service `compatibility` setting key; noted the OpenAI custom service supports text/vision/image/edit.
- **Overview**: corrected stale default models/sizes/quality (gpt-5.5, gpt-5-nano, gpt-image-2, 1024x1024, auto), added `base_output`/`context_prompt` and the image `media_source`/`path`/`download_domains` settings, documented `init.global_chat`/`init.media_browser`/`cache.lit`, and added ImageCropper TV support.
- **Prompt Library**: documented the seeded Text/Image categories and the library's permissions.

## Verification

- `npm run build` (production) passes with no broken links or anchor warnings.
- Dev server (`npm start`) compiled cleanly throughout.
- Content-only PR — no application code changes.

---

## ⚠️ Code bugs found while documenting (out of scope — tracked separately)

Reading the built-in Tool classes to document them surfaced three genuine bugs. They are **not** addressed in this docs PR (and the docs intentionally describe correct/intended behavior, not the buggy behavior). Filing here for visibility; they should be fixed in a separate code PR.

### Bug 1 — `name` filter searches by the wrong argument (`get_chunks`, `get_templates`)
In the `name` branch, the WHERE clause is built from `$arguments['query']` instead of `$arguments['name']`.

- `core/components/modai/src/Tools/GetChunks.php:86` → `['name' => $arguments['query']]`
- `core/components/modai/src/Tools/GetTemplates.php:86` → `['templatename' => $arguments['query']]`

**Repro:** invoke `get_chunks` with `{"name": "myChunk"}` and no `query`. The `if (!empty($arguments['name']))` branch fires, but the filter value is `$arguments['query']` — which is unset (`null`) — so it searches for a chunk literally named `null` and returns nothing. Even if both are supplied, the `name` value is ignored and the `query` value is used. **Fix:** use `$arguments['name']` in that branch.

### Bug 2 — `create_resource` JSON-Schema `required` list doesn't match its properties
`core/components/modai/src/Tools/CreateResource.php:53` declares `"required" => ["name", "description", "content"]`, but the item `properties` (lines 36–48) are `pagetitle`, `template`, `parent`, `content`. So the schema marks two non-existent properties (`name`, `description`) as required, while omitting `template` and `parent` — which the tool body *does* enforce at runtime (`CreateResource.php:102–107` returns "parent is required" / "template is required").

**Repro:** have an agent call `create_resource`. The advertised schema tells the model `name`/`description` are required (they're ignored) and lets it legally omit `template`/`parent`. When the model omits them, `runTool` rejects the call with a runtime "required" error — a contradiction the schema should have prevented. **Fix:** set `"required" => ["pagetitle", "template", "parent", "content"]` (or whichever subset is truly mandatory). Note: `CreateChunk` and `CreateTemplate` are correct — their properties genuinely are `name`/`description`/`content`.

### Bug 3 — `edit_chunk` cache refresh is unreachable on success
`core/components/modai/src/Tools/EditChunk.php:96–104`:

```php
if ($chunk->save()) {
    return json_encode(['success' => true, ...]);  // returns here on success
}

if ($this->clearCache) {                            // only reachable if save() failed
    $this->modx->cacheManager->refresh();
}

return json_encode(['success' => false, 'message' => 'Could not save chunk.']);
```

On a successful save the method returns before the `clearCache` block, so the cache is **never** refreshed after a chunk edit (even though `clear_cache` defaults to on); the refresh is only reachable on the failed-save path, where it does nothing useful.

**Repro:** with `clear_cache` enabled (default), edit a cached chunk via the tool — the rendered output keeps serving the stale cached version until the cache is cleared another way. **Fix:** move the `clearCache` refresh before the success `return` (mirroring `EditTemplate`, which has the correct order: it returns early only on failure, then refreshes, then returns success — so `EditTemplate` is **not** affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
