### PR TITLE
docs: add missing Agents page and fix gitignore that dropped it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ _build/migrations/migrations.lock
 _build/gpm_scripts
 _build/gpm_resolvers
 copilot-instructions.md
-AGENTS.md
+/AGENTS.md

--- a/docs/Admin/Agents.md
+++ b/docs/Admin/Agents.md
@@ -1,0 +1,48 @@
+---
+sidebar_position: 3
+---
+
+# Agents
+
+## What an Agent Is
+
+An **Agent** is a configurable preset that bundles the other modAI building blocks into a specific, reusable AI assistant. An agent can include:
+
+- **[Tools](Tools.md)** for specialized actions (reading/updating MODX elements, calling external APIs, running searches)
+- **[Context Providers](Context-Providers.md)** for grounded, site‑specific information
+- A custom **system prompt** that defines the assistant's behavior and persona
+- **Model parameters** (e.g., temperature) that control response characteristics
+- A specific AI **Model** (in `service/model` format, e.g. `openai/gpt-4o-mini`)
+
+:::info
+Agents are currently the **only** way to utilize Tools and Context Providers within modAI. If you want an assistant to call a Tool or retrieve from a Context Provider, you attach them to an Agent.
+:::
+
+## Creating an Agent
+
+From the **Agents** tab in the modAI admin you can:
+
+- Create a new agent with a **unique name** and description.
+- Choose the **Model** the agent uses.
+- Set a **system prompt** that frames every conversation the agent has.
+- Adjust **model parameters** such as temperature.
+- Attach one or more **Tools** so the agent can take actions.
+- Attach one or more **Context Providers** so the agent can ground its answers in your data.
+
+Because agents are configured in the Manager rather than in code, you can iterate on prompts, swap models, and add or remove tools without redeploying.
+
+## Controlling Access
+
+Access to a specific agent is controlled by assigning one or more **user groups** to it:
+
+- If **no** user group is assigned, the agent is available to everyone who can use modAI.
+- If one or more user groups are assigned, only members of those groups see the agent.
+- **Sudo** users always have access to every agent, regardless of the groups specified.
+
+See [Permissions](../Configuration/Permissions.md) for the full list of `modai_admin_agent_*` and client permissions that govern who can create, edit, and use agents.
+
+## Design Tips
+
+- Keep each agent **narrowly scoped** — a focused agent (e.g., "SEO Assistant" or "Support Answer Drafter") produces more predictable results than a do‑everything one.
+- Bind **write or delete Tools** to admin‑only agents, and restrict those agents to trusted user groups.
+- Pair an agent with only the **Context Providers** it actually needs, to keep retrieval relevant and token usage down.


### PR DESCRIPTION
## What

Fixes the failing **Docs / Build Docusaurus** workflow on `main`. Adds the missing `docs/Admin/Agents.md` page and corrects the `.gitignore` rule that caused it to be dropped.

## Why it broke

The deploy workflow failed with:

```
[ERROR] Docusaurus found broken links!
- Broken link on source page path = /modAI/Admin/Tools:
   -> linking to Agents.md
- Broken link on source page path = /modAI/Configuration/Chat:
   -> linking to ../Admin/Agents.md
   -> linking to ../Admin/Agents.md#controlling-access
```

`Tools.md` and `Chat.md` (merged in #107) link to an **Agents** page — but `docs/Admin/Agents.md` was never actually committed. Root cause:

- `.gitignore` contained an **unanchored** rule `AGENTS.md` (intended for the repo-root agent-instructions file).
- The repo has `core.ignorecase=true` (macOS, case-insensitive filesystem), so git matched that pattern against **`docs/Admin/Agents.md`** too.
- `git add docs/` therefore **silently skipped** the new page. The local `npm run build` still passed because the untracked file was physically on disk — but CI checks out only tracked files, so the page was absent and the inbound links broke.

## The fix

- **Anchor the rule** to `/AGENTS.md` so it only ignores the root file (verified: root `AGENTS.md` stays ignored; `docs/Admin/Agents.md` no longer is).
- **Add** the previously-dropped `docs/Admin/Agents.md`.

## Verification

- `git check-ignore`: root `AGENTS.md` still ignored ✓, `docs/Admin/Agents.md` no longer ignored ✓.
- `npm run build` (production) passes with **no broken links** and no warnings.
- Re-run the **Docs** workflow (it's `workflow_dispatch`) after merge to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
