### PR TITLE
fix: correct three bugs in built-in Tools

### DIFF
--- a/core/components/modai/src/Tools/CreateResource.php
+++ b/core/components/modai/src/Tools/CreateResource.php
@@ -50,7 +50,7 @@ class CreateResource implements ToolInterface
                                 "description" => 'The content of the new resource. Generate this based on the users\' prompt. Allow the user to iterate on the content to create before finally calling the appropriate tool. Generate the content as HTML.'
                             ],
                         ],
-                        "required" => ["name", "description", 'content']
+                        "required" => ["pagetitle", "template", "parent", 'content']
                     ],
                     "description" => "List of resources to create"
                 ],

--- a/core/components/modai/src/Tools/EditChunk.php
+++ b/core/components/modai/src/Tools/EditChunk.php
@@ -93,15 +93,15 @@ class EditChunk implements ToolInterface
         }
         $chunk->set('description', (string)$arguments['chunk']['description']);
         $chunk->set('snippet', (string)$arguments['chunk']['content']);
-        if ($chunk->save()) {
-            return json_encode(['success' => true, 'message' => 'Chunk updated. Use with: [[$' . $chunk->get('name') . ']]']);
+        if (!$chunk->save()) {
+            return json_encode(['success' => false, 'message' => 'Could not save chunk.']);
         }
 
         if ($this->clearCache) {
             $this->modx->cacheManager->refresh();
         }
 
-        return json_encode(['success' => false, 'message' => 'Could not save chunk.']);
+        return json_encode(['success' => true, 'message' => 'Chunk updated. Use with: [[$' . $chunk->get('name') . ']]']);
     }
 
     public static function checkPermissions(modX $modx): bool

--- a/core/components/modai/src/Tools/GetChunks.php
+++ b/core/components/modai/src/Tools/GetChunks.php
@@ -83,7 +83,7 @@ class GetChunks implements ToolInterface
 
             if (!empty($arguments['name'])) {
                 $where[] = [
-                    'name' => $arguments['query'],
+                    'name' => $arguments['name'],
                 ];
             }
 

--- a/core/components/modai/src/Tools/GetTemplates.php
+++ b/core/components/modai/src/Tools/GetTemplates.php
@@ -83,7 +83,7 @@ class GetTemplates implements ToolInterface
 
             if (!empty($arguments['name'])) {
                 $where[] = [
-                    'templatename' => $arguments['query'],
+                    'templatename' => $arguments['name'],
                 ];
             }
 


### PR DESCRIPTION
## What

Fixes three bugs in modAI's built-in Tool classes, discovered while documenting them (see #107). Verified by reading the code; each is a small, targeted change.

## Bugs fixed

### 1. `name` filter searches by the wrong argument (`get_chunks`, `get_templates`)
The `name` branch built its WHERE clause from `$arguments['query']` instead of `$arguments['name']`.

- `GetChunks.php` → `['name' => $arguments['query']]`
- `GetTemplates.php` → `['templatename' => $arguments['query']]`

**Effect:** calling `get_chunks` with `{"name": "myChunk"}` and no `query` filtered on the unset query value (`null`) and returned nothing. With both supplied, the `name` value was ignored. **Fix:** use `$arguments['name']`.

### 2. `create_resource` schema `required` list didn't match its properties
`CreateResource.php` declared `"required" => ["name", "description", "content"]`, but the item properties are `pagetitle`, `template`, `parent`, `content`. So it marked two non-existent properties as required while omitting `template`/`parent` — which `runTool` enforces at runtime.

**Effect:** the advertised schema let the model omit `template`/`parent`, then the tool rejected the call with a runtime "required" error. **Fix:** `"required" => ["pagetitle", "template", "parent", "content"]`. (`CreateChunk`/`CreateTemplate` were already correct and are unchanged.)

### 3. `edit_chunk` cache refresh was unreachable on success
`EditChunk.php` returned the success response *before* the `clear_cache` refresh block, so the cache was never refreshed after a successful chunk edit (the refresh was only reachable on the failed-save path).

**Effect:** with `clear_cache` enabled (default), editing a cached chunk left stale output cached. **Fix:** inverted the save check so the refresh runs before the success return — mirroring `EditTemplate`, which already had the correct order and is **not** changed.

## Notes

- 4 files, 6 lines changed. No behavior changes beyond the fixes above.
- Found during the docs work in #107; that PR intentionally documents the *correct* behavior, and these are the corresponding code fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
